### PR TITLE
Add eta-mixing and few general changes in the code and random mixing

### DIFF
--- a/eta_mixing.h
+++ b/eta_mixing.h
@@ -1,0 +1,102 @@
+
+void MixEvents_eta(int ntrkoff_min, int ntrkoff_max, std::vector<std::pair<Double_t, std::vector<TLorentzVector>> > ev_GoodTrackFourVector_etaMixWeight_vec, std::vector<std::pair<Double_t, std::vector<int>> > ev_GoodTrackCharge_etaMixWeight_vec, std::vector<std::pair<Double_t,int> > ev_ntrkoff_etaMixWeight_vec){
+
+///sort vectors of maps for each ntrkoffline range
+std::vector<std::pair<Double_t, std::vector<TLorentzVector>> > aux_ev_GoodTrackFourVector_etaMixWeight_vec;
+std::vector<std::pair<Double_t, std::vector<int>> > aux_ev_GoodTrackCharge_etaMixWeight_vec;
+std::vector<std::pair<Double_t,int> > aux_ev_ntrkoff_etaMixWeight_vec;
+
+
+int aux_n_evts = ev_GoodTrackFourVector_etaMixWeight_vec.size();
+
+for(int ievt=0; ievt<aux_n_evts; ievt++){
+
+   if((ev_ntrkoff_etaMixWeight_vec[ievt]).second<ntrkoff_min || ntrkoff_max<(ev_ntrkoff_etaMixWeight_vec[ievt]).second)continue; //only events in a given range
+
+   aux_ev_GoodTrackFourVector_etaMixWeight_vec.push_back(ev_GoodTrackFourVector_etaMixWeight_vec[ievt]);
+   aux_ev_GoodTrackCharge_etaMixWeight_vec.push_back(ev_GoodTrackCharge_etaMixWeight_vec[ievt]);
+   aux_ev_ntrkoff_etaMixWeight_vec.push_back(ev_ntrkoff_etaMixWeight_vec[ievt]);
+
+}
+
+std::sort( aux_ev_GoodTrackFourVector_etaMixWeight_vec.begin(), aux_ev_GoodTrackFourVector_etaMixWeight_vec.end(), etaMixSort );
+std::sort( aux_ev_GoodTrackCharge_etaMixWeight_vec.begin(), aux_ev_GoodTrackCharge_etaMixWeight_vec.end(), etaMixSort_ch );
+std::sort( aux_ev_ntrkoff_etaMixWeight_vec.begin(), aux_ev_ntrkoff_etaMixWeight_vec.end(), etaMixSort_ntrkoff );
+
+
+int aux_n_evts_inNtrkoffRange = aux_ev_GoodTrackFourVector_etaMixWeight_vec.size();
+
+//auxiliar vectors for mixing
+std::vector<TLorentzVector> ev_GoodTrackFourVectorTemp_nevt1_vec;
+int nMixmult_nevt1;
+std::vector<int> ev_GoodTrackChargeTemp_nevt1_vec;
+
+std::vector<TLorentzVector> ev_GoodTrackFourVectorTemp_nevt_assoc_vec;
+int nMixmult_nevt_assoc;
+std::vector<int> ev_GoodTrackChargeTemp_nevt_assoc_vec;
+
+//loop in the vector of maps for mixing - only in a given range of ntrkoffline
+for(int nevt=0; nevt+1<aux_n_evts_inNtrkoffRange; nevt+=2) {
+
+
+   ev_GoodTrackFourVectorTemp_nevt1_vec= (aux_ev_GoodTrackFourVector_etaMixWeight_vec[nevt]).second;
+   nMixmult_nevt1=ev_GoodTrackFourVectorTemp_nevt1_vec.size();
+   ev_GoodTrackChargeTemp_nevt1_vec = (aux_ev_GoodTrackCharge_etaMixWeight_vec[nevt]).second;
+
+   ev_GoodTrackFourVectorTemp_nevt_assoc_vec= (aux_ev_GoodTrackFourVector_etaMixWeight_vec[nevt+1]).second;
+   nMixmult_nevt_assoc=ev_GoodTrackFourVectorTemp_nevt_assoc_vec.size();
+   ev_GoodTrackChargeTemp_nevt_assoc_vec= (aux_ev_GoodTrackCharge_etaMixWeight_vec[nevt+1]).second;
+
+
+   for(int imix=0; imix<nMixmult_nevt1; imix++){
+      for(int iimix=0; iimix<nMixmult_nevt_assoc; iimix++){
+         if(splitcomb(ev_GoodTrackFourVectorTemp_nevt1_vec[imix],ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix])){continue;}
+         Double_t qmix = GetQ(ev_GoodTrackFourVectorTemp_nevt1_vec[imix], ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix]);
+         Double_t qmixlong = GetQlong(ev_GoodTrackFourVectorTemp_nevt1_vec[imix],ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix]);
+         Double_t qmixlongLCMS = GetQlongLCMS(ev_GoodTrackFourVectorTemp_nevt1_vec[imix],ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix]);
+         Double_t qmixout = GetQout(ev_GoodTrackFourVectorTemp_nevt1_vec[imix],ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix]);
+         Double_t qmixside = GetQside(ev_GoodTrackFourVectorTemp_nevt1_vec[imix],ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix]);
+
+         TLorentzVector psum2 = ev_GoodTrackFourVectorTemp_nevt1_vec[imix]+ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix];
+         Double_t kt=(psum2.Pt())/2.;
+
+         Double_t xmix3D[3]={qmix,kt,(Double_t)(aux_ev_ntrkoff_etaMixWeight_vec[nevt]).second};
+         Double_t xmix5D_LCMS[5]={qmixlongLCMS,qmixout,qmixside,kt,(Double_t)(aux_ev_ntrkoff_etaMixWeight_vec[nevt]).second};
+
+         //Double_t aux_tk1_corr = (Double_t)getTrkCorrWeight(ev_GoodTrackFourVectorTemp_nevt1_vec[imix].Pt(),ev_GoodTrackFourVectorTemp_nevt1_vec[imix].Eta());
+         //Double_t aux_tk2_corr = (Double_t)getTrkCorrWeight(ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix].Pt(),ev_GoodTrackFourVectorTemp_nevt_assoc_vec[iimix].Eta());
+         //Double_t aux_tk12_corr= aux_tk1_corr*aux_tk2_corr;
+	 Double_t aux_tk12_corr=1.;
+         if(ev_GoodTrackChargeTemp_nevt1_vec[imix]*ev_GoodTrackChargeTemp_nevt_assoc_vec[iimix]>0){
+
+            hist_mixsch_KtVsNch_ntrkoff->Fill(kt,(aux_ev_ntrkoff_etaMixWeight_vec[nevt]).second,aux_tk12_corr);
+
+            hist_qinv_mixschVsKtVsNch_ntrkoff->Fill(xmix3D,aux_tk12_corr);
+            hist_qLLCMSqOqSmixschVsKtVsNch_ntrkoff->Fill(xmix5D_LCMS,aux_tk12_corr);
+
+         }else{
+
+            hist_qinv_mixdchVsKtVsNch_ntrkoff->Fill(xmix3D,aux_tk12_corr);
+            hist_qLLCMSqOqSmixdchVsKtVsNch_ntrkoff->Fill(xmix5D_LCMS,aux_tk12_corr);
+
+         }
+      }
+   }
+
+
+
+}//end first for loop
+
+//clear vectors for next ntrkoff range
+aux_ev_GoodTrackFourVector_etaMixWeight_vec.clear();
+aux_ev_GoodTrackCharge_etaMixWeight_vec.clear();
+aux_ev_ntrkoff_etaMixWeight_vec.clear();
+
+
+}//end MixEvents_eta function
+
+void call_mix_eta(int ntrkoff_min, int ntrkoff_max, std::vector<std::pair<Double_t, std::vector<TLorentzVector>> > ev_GoodTrackFourVector_etaMixWeight_vec, std::vector<std::pair<Double_t, std::vector<int>> > ev_GoodTrackCharge_etaMixWeight_vec, std::vector<std::pair<Double_t,int> > ev_ntrkoff_etaMixWeight_vec){
+
+MixEvents_eta(ntrkoff_min, ntrkoff_max, ev_GoodTrackFourVector_etaMixWeight_vec, ev_GoodTrackCharge_etaMixWeight_vec, ev_ntrkoff_etaMixWeight_vec);
+
+}

--- a/histogram_definition_bec.h
+++ b/histogram_definition_bec.h
@@ -98,7 +98,7 @@ THnSparseD *hist_gen_trk = new THnSparseD("hist_gen_trk", "hist_gen_trk", 4, bin
 THnSparseD *hist_gen_trk_weighted = new THnSparseD("hist_gen_trk_weighted", "hist_gen_trk_weighted", 4, bins4D_trk, xmin4D_trk, xmax4D_trk);
 
 
-
+/*
 bool splitcomb(TLorentzVector &vec1,TLorentzVector &vec2){
   bool issplit=false;
   Double_t cosa = TMath::Abs(vec1.Px()*vec2.Px() + vec1.Py()*vec2.Py() + vec1.Pz()*vec2.Pz())/(vec1.P()*vec2.P());
@@ -129,13 +129,6 @@ Double_t GetQlongLCMS(const TLorentzVector &p1, const TLorentzVector &p2){
 }
 
 Double_t GetQout(const TLorentzVector &p1, const TLorentzVector &p2){
-  /*Double_t kT_norm = TMath::Hypot((p1.Px()+p2.Px())/2.0,(p1.Py()+p2.Py())/2.0);                                                
-   Double_t qT_dot_kT = (p1.Px()-p2.Px())*((p1.Px()+p2.Px())/2) + (p1.Py()-p2.Py())*((p1.Py()+p2.Py())/2);                        
-                                                                                                                                  
-   Double_t qout = 0.0;                                                                                                           
-   if(kT_norm != 0) qout = qT_dot_kT/kT_norm;                                                                                     
-   return qout;                                                                                                                   
-  */
   TVector3 qT;
   qT.SetXYZ(p1.Px()-p2.Px(),p1.Py()-p2.Py(),0.0);
   TVector3 kT;
@@ -152,25 +145,6 @@ Double_t GetQout(const TLorentzVector &p1, const TLorentzVector &p2){
 }
 
 Double_t GetQside(const TLorentzVector &p1, const TLorentzVector &p2){
-
-  /*Double_t qT_x = p1.Px()-p2.Px();                                                                                             
-   Double_t qT_y = p1.Py()-p2.Py();                                                                                               
-                                                                                                                                  
-   Double_t kT_norm = TMath::Hypot((p1.Px()+p2.Px())/2.0,(p1.Py()+p2.Py())/2.0);                                                  
-   Double_t qT_dot_kT = (p1.Px()-p2.Px())*((p1.Px()+p2.Px())/2) + (p1.Py()-p2.Py())*((p1.Py()+p2.Py())/2);                        
-   Double_t kT_norm_x = ((p1.Px()+p2.Px())/2.0)/kT_norm;                                                                          
-   Double_t qOut_x = (qT_dot_kT*kT_norm_x)/kT_norm;                                                                               
-   Double_t kT_norm_y = ((p1.Py()+p2.Py())/2.0)/kT_norm;                                                                          
-   Double_t qOut_y = (qT_dot_kT*kT_norm_y)/kT_norm;                                                                               
-                                                                                                                                  
-   Double_t qSide_x = qT_x - qOut_x;                                                                                              
-   Double_t qSide_y = qT_y - qOut_y;                                                                                              
-   Double_t qSide = TMath::Hypot(qSide_x,qSide_y);                                                                                
-                                                                                                                                  
-   if (qSide_y<0)qSide=-1.*qSide;                                                                                                 
-                                                                                                                                  
-   return qSide;                                                                                                                  
-  */
 
   TVector3 qT;
   qT.SetXYZ(p1.Px()-p2.Px(),p1.Py()-p2.Py(),0.0);
@@ -228,41 +202,10 @@ const  Double_t CoulombWpm(const Double_t& q){
   //Double_t weight = 0.85; //for syst. -15%                                                                                    
   return weight*( (1.-TMath::Exp(-x))/x -1 ) + 1;
 }
-
-
-
-
-
-/*
-double getTrkCorrWeight(double pT, double eta){
-
-  double eff = reff2D->GetBinContent(
-				     reff2D->GetXaxis()->FindBin(eta),
-				     reff2D->GetYaxis()->FindBin(pT) );
-  if(eff >= 0.9999 || eff <= 0.0001) eff = 1;
-
-  double sec = rsec2D->GetBinContent(
-				     rsec2D->GetXaxis()->FindBin(eta),
-				     rsec2D->GetYaxis()->FindBin(pT));
-  if( sec >= 0.9999 || sec <= 0.0001) sec = 0;
-
-  double fak = rfak2D->GetBinContent(
-				     rfak2D->GetXaxis()->FindBin(eta),
-				     rfak2D->GetYaxis()->FindBin(pT));
-  if( fak >= 0.9999 || fak <= 0.0001) fak = 0;
-
-  double mul = rmul2D->GetBinContent(
-				     rmul2D->GetXaxis()->FindBin(eta),
-				     rmul2D->GetYaxis()->FindBin(pT));
-  if( mul >= 0.9999 || mul <= 0.0001) mul = 0;
-
-
-  return (1. - fak ) * ( 1. - sec ) / eff  / (1. + mul );
-  //return (1. - fak ) / eff;                                                                                                     
-  //return 1. / eff;                                                                                                              
-
-}
 */
+
+
+
 
 
 

--- a/random_mixing.h
+++ b/random_mixing.h
@@ -43,6 +43,7 @@ void MixEvents_random(int ntrkoff_min, int ntrkoff_max, int nEvt_to_mix, std::ve
     int takeAssociated = 0;
     for(int nevt_assoc=nevt1+1; nevt_assoc<aux_n_evts; nevt_assoc++) {
       if(ev_ntrkoff_vec[nevt_assoc]<ntrkoff_min || ntrkoff_max<ev_ntrkoff_vec[nevt_assoc])continue;
+      if(std::abs((ev_vtx_z_vec)[nevt1] - (ev_vtx_z_vec)[nevt_assoc])>2.0) continue; //do not mix events far away 2cm in Z 
 
       std::vector<TLorentzVector> ev_GoodTrackFourVectorTemp_nevt_assoc_vec= ev_GoodTrackFourVector_vec[nevt_assoc];
       int nMixmult_nevt_assoc=ev_GoodTrackFourVectorTemp_nevt_assoc_vec.size();


### PR DESCRIPTION
Hello Sunil, 
this PR introduces the eta-mixing.
I also did some fixes in the code... In particular, for random mix, I added a criteria to mix only event with distance in Z less than 2cm.
So, for eta-mixing the number of entries will be much less than the random mixing, but this is expected since it only mix events with similar track eta configurations...
Please, have a look. 


Best Regards.